### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/pyxa/utils/common.py
+++ b/pyxa/utils/common.py
@@ -115,8 +115,8 @@ def find_string(string: str,
     Raises:
         ValueError: If the string couldn't be found in the passed list.
     """
-    from fuzzywuzzy.fuzz import partial_ratio
-    from fuzzywuzzy.process import extract
+    from rapidfuzz.fuzz import partial_ratio
+    from rapidfuzz.process import extract
 
     # This will give us list of 3 best matches for our search query.
     guessed = extract(string, string_list, limit=3, scorer=partial_ratio)

--- a/pyxa/utils/system.py
+++ b/pyxa/utils/system.py
@@ -147,8 +147,8 @@ def find_file(file: str,
     Raises:
         FileNotFoundError: If file not found.
     """
-    from fuzzywuzzy.fuzz import partial_ratio
-    from fuzzywuzzy.process import extract
+    from rapidfuzz.fuzz import partial_ratio
+    from rapidfuzz.process import extract
 
     # This will give us list of 3 best matches for our search query.
     guessed = extract(file,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-fuzzywuzzy
+rapidfuzz
 geocoder
 geolocation-python
 googlemaps
 hurry.filesize
-python-Levenshtein
 reverse-geocode

--- a/setup.py
+++ b/setup.py
@@ -43,12 +43,11 @@ DOCLINES = __doc__.split('\n')
 VERSION = PACKAGE_VERSION
 
 REQUIRED_PACKAGES = [
-    'fuzzywuzzy',
+    'rapidfuzz',
     'geocoder',
     'geolocation-python',
     'googlemaps',
     'hurry.filesize',
-    'python-Levenshtein',
     'reverse-geocode']
 
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy